### PR TITLE
s5neolte: change generated directory name in vendor

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -142,4 +142,4 @@ PRODUCT_COPY_FILES += \
 $(call inherit-product, device/samsung/universal7580-common/device-common.mk)
 
 # call the proprietary setup
-$(call inherit-product, vendor/samsung/s5neolte/s5neolte-vendor.mk)
+$(call inherit-product, vendor/samsung/universal7580-common/universal7580-common-vendor.mk)

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -18,7 +18,7 @@
 set -e
 
 VENDOR=samsung
-DEVICE=s5neolte
+DEVICE=universal7580-common
 
 export INITIAL_COPYRIGHT_YEAR=2017
 


### PR DESCRIPTION
* extract-files.sh generates a directory in /vendor
  that makes the breakfast command to fail in clean
  repo.
  This commit fixes this issue.

Change-Id: I72c0ba6a6c3c869082250fcab722c1379742e05f