### PR TITLE
s5neolte: change generated directory name in vendor

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -142,4 +142,4 @@ PRODUCT_COPY_FILES += \
 $(call inherit-product, device/samsung/universal7580-common/device-common.mk)
 
 # call the proprietary setup
-$(call inherit-product, vendor/samsung/s5neolte/s5neolte-vendor.mk)
+$(call inherit-product, vendor/samsung/universal7580-common/universal7580-common-vendor.mk)

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-DEVICE=s5neolte
+DEVICE=universal7580-common
 VENDOR=samsung
 
 # Load extract_utils and do some sanity checks

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-DEVICE=s5neolte
+DEVICE=universal7580-common
 VENDOR=samsung
 
 # Load extract_utils and do some sanity checks


### PR DESCRIPTION
* extract-files.sh generates a directory in /vendor
  that makes the breakfast command to fail in clean
  repo.
  This commit fixes this issue.

Change-Id: Ib062a5108d4048d46ea8218a5f400e93225d9234